### PR TITLE
[FEAT] pseudo_labeling 파일 공유

### DIFF
--- a/utils/inference_pseudo.ipynb
+++ b/utils/inference_pseudo.ipynb
@@ -1,0 +1,280 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import shutil\n",
+    "import glob\n",
+    "from mmcv import Config\n",
+    "from mmseg.datasets import build_dataloader, build_dataset\n",
+    "from mmseg.models import build_segmentor\n",
+    "from mmseg.apis import single_gpu_test\n",
+    "from mmcv.runner import load_checkpoint\n",
+    "from mmcv.parallel import MMDataParallel\n",
+    "\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# config file_dir, work_dir 수정 후 사용\n",
+    "\n",
+    "# config file 들고오기\n",
+    "cfg = Config.fromfile('/opt/ml/input/code/mmsegmentation/configs/_boostcamp_/_base_/upernet-swin-l-aug.py') # load config file\n",
+    "root='/opt/ml/input/data/mmseg/test'\n",
+    "epoch = 'latest'\n",
+    "\n",
+    "# dataset config 수정\n",
+    "cfg.work_dir = '/opt/ml/input/code/work_dirs/upernet-swin-l-focal-aug-v2-f1' # set work_dir\n",
+    "cfg.data.test.img_dir = root\n",
+    "cfg.data.test.pipeline[1]['img_scale'] = (512,512) # Resize\n",
+    "cfg.data.test.test_mode = True\n",
+    "cfg.data.samples_per_gpu = 1\n",
+    "cfg.optimizer_config.grad_clip = dict(max_norm=35, norm_type=2)\n",
+    "cfg.model.train_cfg = None\n",
+    "\n",
+    "# checkpoint path\n",
+    "checkpoint_path = os.path.join(cfg.work_dir, f'{epoch}.pth')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2022-05-11 05:11:50,935 - mmseg - INFO - Loaded 624 images\n"
+     ]
+    }
+   ],
+   "source": [
+    "dataset = build_dataset(cfg.data.test)\n",
+    "data_loader = build_dataloader(\n",
+    "        dataset,\n",
+    "        samples_per_gpu=cfg.data.samples_per_gpu,\n",
+    "        workers_per_gpu=cfg.data.workers_per_gpu,\n",
+    "        dist=False,\n",
+    "        shuffle=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "load checkpoint from local path: /opt/ml/input/code/work_dirs/upernet-swin-l-focal-aug-v2-f1/latest.pth\n"
+     ]
+    }
+   ],
+   "source": [
+    "model = build_segmentor(cfg.model, test_cfg=cfg.get('test_cfg'))\n",
+    "checkpoint = load_checkpoint(model, checkpoint_path, map_location='cpu')\n",
+    "\n",
+    "model.CLASSES = dataset.CLASSES\n",
+    "model = MMDataParallel(model.cuda(), device_ids=[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[>>>>>>>>>>>>>>>>>>>>>>>>>>>>] 624/624, 0.5 task/s, elapsed: 1151s, ETA:     0s"
+     ]
+    }
+   ],
+   "source": [
+    "output = single_gpu_test(model, data_loader)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(624, 512, 512)"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#shape 확인\n",
+    "np.array(output).shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_img_root = glob.glob('/opt/ml/input/data/mmseg/images5/training/*.*')\n",
+    "train_ann_root = sorted(glob.glob('/opt/ml/input/data/mmseg/annotations5/training/*.*'))\n",
+    "images = sorted(glob.glob('/opt/ml/input/data/mmseg/test/*.jpg'))\n",
+    "\n",
+    "last_img = train_ann_root[-1].split('/')[-1].split('.')[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from PIL import Image\n",
+    "category_names = [\n",
+    "    'Backgroud',\n",
+    "    'General trash',\n",
+    "    'Paper',\n",
+    "    'Paper pack',\n",
+    "    'Metal',\n",
+    "    'Glass',\n",
+    "    'Plastic',\n",
+    "    'Styrofoam',\n",
+    "    'Plastic bag',\n",
+    "    'Battery',\n",
+    "    'Clothing'\n",
+    "    ]\n",
+    "\n",
+    "category_colors =[\n",
+    "    [0,0,0],\n",
+    "    [192,0,128],\n",
+    "    [0,128,192],\n",
+    "    [0,128,64],\n",
+    "    [128,0,0],\n",
+    "    [64,0,128],\n",
+    "    [64,0,192],\n",
+    "    [192,128,64],\n",
+    "    [192,192,128],\n",
+    "    [64,64,128],\n",
+    "    [128,0,192]\n",
+    "]\n",
+    "\n",
+    "category_list = list()\n",
+    "for category in category_colors:\n",
+    "    category_list.extend(category)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "#test image copy\n",
+    "for image in images:\n",
+    "    file_name = int(last_img) + int(image.split('/')[-1].split('.')[0]) + 1\n",
+    "    shutil.copyfile(image, os.path.join('/opt/ml/input/data/mmseg/images_pseudo/training', f\"{file_name}.jpg\"))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "##psuedo labeling png 생성\n",
+    "for idx, predict in enumerate(output):\n",
+    "    file_name = int(last_img) + idx + 1\n",
+    "    a = predict\n",
+    "    a=a.astype(np.uint8)\n",
+    "    img_png = Image.fromarray(a).convert('P')\n",
+    "    img_png.putpalette(category_list)\n",
+    "    img_png.save(os.path.join('/opt/ml/input/data/mmseg/annotations_pseudo/training',f'{file_name}.png'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## submission파일 만들기\n",
+    "# sample_submisson.csv 열기\n",
+    "submission = pd.read_csv('/opt/ml/input/code/submission/sample_submission.csv', index_col=None)\n",
+    "json_dir = os.path.join(\"/opt/ml/input/data/test.json\")\n",
+    "with open(json_dir, \"r\", encoding=\"utf8\") as outfile:\n",
+    "    datas = json.load(outfile)\n",
+    "\n",
+    "input_size = 512\n",
+    "output_size = 256\n",
+    "bin_size = input_size // output_size\n",
+    "\t\t\n",
+    "# PredictionString 대입\n",
+    "for image_id, predict in enumerate(output):\n",
+    "    image_id = datas[\"images\"][image_id]\n",
+    "    file_name = image_id[\"file_name\"]\n",
+    "    \n",
+    "    temp_mask = []\n",
+    "    predict = predict.reshape(1, 512, 512)\n",
+    "    # resize predict to 256, 256\n",
+    "    # reference : https://stackoverflow.com/questions/48121916/numpy-resize-rescale-image\n",
+    "    mask = predict.reshape((1, output_size, bin_size, output_size, bin_size)).max(4).max(2) \n",
+    "    temp_mask.append(mask)\n",
+    "    oms = np.array(temp_mask)\n",
+    "    oms = oms.reshape([oms.shape[0], output_size*output_size]).astype(int)\n",
+    "\n",
+    "    string = oms.flatten()\n",
+    "\n",
+    "    submission = submission.append({\"image_id\" : file_name, \"PredictionString\" : ' '.join(str(e) for e in string.tolist())}, \n",
+    "                                   ignore_index=True)\n",
+    "\n",
+    "# submission.csv로 저장\n",
+    "submission.to_csv(os.path.join(cfg.work_dir, f'submission_{epoch}.csv'), index=False)"
+   ]
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "c31e71a5e498f0aaae29fa2d4fcce91b7642bc45d7bb4c98f573abb4911baaab"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.7.13 ('mmseg')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.13"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## 정보
- inference한 output에서 mask를 가져와 pseudo labeling 진행
- test 파일을 mmseg/images/training에 복사 (jpg)
- anno 파일을 mmseg/annotations/training에 생성 (png)

## 사용 방법
- 주소 위치 변경 후 순서대로 돌리면 됩니다.
- 마지막 셀을 돌리면 submission.csv 파일이 생성됩니다 (필요없으면 제외하시면 됩니다)